### PR TITLE
feat: set login as default route and fix API URL configuration

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,7 +1,8 @@
 # Frontend Environment Variables
 
 # API Configuration
-VITE_API_URL=http://localhost:8002
+VITE_API_URL=http://localhost:8002/api
+VITE_WS_URL=http://localhost:8002
 
 # App Configuration
 VITE_APP_NAME=Thundershot

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route, Link, Navigate } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { Camera } from 'lucide-react';
 import { Toaster } from 'sonner';
 import LoginPage from './components/pages/LoginPage';
@@ -12,26 +12,7 @@ import { ConfigsPage } from './components/pages/ConfigsPage';
 import { useAuth } from './hooks/useAuth';
 import './index.css';
 
-// Simple components
-const HomePage = () => (
-  <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-50 flex items-center justify-center">
-    <div className="text-center">
-      <div className="flex items-center justify-center space-x-2 mb-8">
-        <Camera className="h-12 w-12 text-blue-600" />
-        <h1 className="text-4xl font-bold text-gray-900">Screenshot SaaS</h1>
-      </div>
-      <p className="text-xl text-gray-600 mb-8">Capture screenshots at scale with our powerful API</p>
-      <div className="space-x-4">
-        <Link to="/login" className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
-          Login
-        </Link>
-        <Link to="/signup" className="px-6 py-3 border border-blue-600 text-blue-600 rounded-lg hover:bg-blue-50">
-          Sign Up
-        </Link>
-      </div>
-    </div>
-  </div>
-);
+
 
 // Protected Route Component
 const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
@@ -82,7 +63,7 @@ function App() {
     <Router>
       <Routes>
         {/* Public Routes */}
-        <Route path="/" element={<HomePage />} />
+        <Route path="/" element={<Navigate to="/login" replace />} />
         <Route 
           path="/login" 
           element={

--- a/frontend/src/components/pages/ProjectDetailPage.tsx
+++ b/frontend/src/components/pages/ProjectDetailPage.tsx
@@ -552,13 +552,7 @@ const ProjectDetailPage: React.FC = () => {
           />
         </div>
 
-        {/* Socket Connection Status */}
-        {isConnected && (
-          <div className="flex items-center space-x-2 text-sm text-green-600 dark:text-green-400">
-            <Wifi className="h-4 w-4" />
-            <span>Live updates connected</span>
-          </div>
-        )}
+
 
         {/* Professional Screenshots Grid */}
         {filteredScreenshots.length === 0 ? (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,6 @@
 import axios, { type AxiosInstance } from 'axios'
 
-const API_BASE_URL = import.meta.env.VITE_API_URL ? `${import.meta.env.VITE_API_URL}/api` : 'http://localhost:8002/api'
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8002/api'
 
 class ApiClient {
   private client: AxiosInstance


### PR DESCRIPTION
- Change default route from HomePage to redirect directly to /login
- Remove unused HomePage component and Link import to clean up code
- Fix API base URL configuration to prevent double /api appending:
  * Set VITE_API_URL=http://localhost:8002/api in environment
  * Update API client to use environment variable directly
  * Add VITE_WS_URL=http://localhost:8002 for WebSocket connections
- Remove duplicate 'Live updates connected' indicator:
  * Keep only the dynamic indicator near Add Screenshot button
  * Remove redundant static indicator below search area

This improves user experience by going directly to login and fixes API URL construction issues that were causing double /api paths.